### PR TITLE
[BUGFIX] Add common fields to feAdmin editable field list

### DIFF
--- a/Configuration/TCA/Overrides/tt_address.php
+++ b/Configuration/TCA/Overrides/tt_address.php
@@ -3,4 +3,4 @@ if (!defined('TYPO3_MODE')) {
     die('Access denied.');
 }
 
-$GLOBALS['TCA']['tt_address']['feInterface']['fe_admin_fieldList'] .= ',name';
+$GLOBALS['TCA']['tt_address']['feInterface']['fe_admin_fieldList'] .= ',hidden,gender,name,email,first_name,last_name,company';


### PR DESCRIPTION
This adds the most common fields of tt_address to the allowed editable fields so the feAdmin
can create a correct data structure for the insert query out of the box. 

Fixes: #9 