### PR TITLE
[BUGFIX] add missing class loading

### DIFF
--- a/fe_adminLib.inc
+++ b/fe_adminLib.inc
@@ -30,6 +30,8 @@ use TYPO3\CMS\Core\Utility\ExtensionManagementUtility;
 use TYPO3\CMS\Core\Utility\GeneralUtility;
 use TYPO3\CMS\Core\Utility\MathUtility;
 
+require_once ExtensionManagementUtility::extPath('direct_mail_subscription') . 'pi/class.dmailsubscribe.php';
+
 /**
  * FE admin lib.
  *


### PR DESCRIPTION
Without (auto)loading the class name the method user_dmaiulsubscribe->saveRecord() cannot be called for the localized salutation in table column 'tx_directmailsubscription_localgender'.