### PR TITLE
[TASK] Fixed PHP Deprecation Error Methods

### DIFF
--- a/pi/class.dmailsubscribe.php
+++ b/pi/class.dmailsubscribe.php
@@ -70,7 +70,7 @@ class user_dmailsubscribe
     /**
      * Constructor.
      */
-    public function user_dmailsubscribe()
+    public function __construct()
     {
         $this->cObj = GeneralUtility::makeInstance('TYPO3\\CMS\\Frontend\\ContentObject\\ContentObjectRenderer');
         $this->conf = $GLOBALS['TSFE']->tmpl->setup['plugin.']['feadmin.']['dmailsubscription.'];


### PR DESCRIPTION
PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; user_dmailsubscribe has a deprecated constructor in /typo3conf/ext/direct_mail_subscription/pi/class.dmailsubscribe.php on line 4