### PR TITLE
Compatibility with "captcha" >= 2.0.0 and a little bugfix

### DIFF
--- a/fe_adminLib.inc
+++ b/fe_adminLib.inc
@@ -784,11 +784,14 @@ class user_feAdmin
         $captcha = true;
 
         if (ExtensionManagementUtility::isLoaded('captcha') && isset($this->dataArr['captcha'])) {
-            session_start();
-            $captchaStr = $_SESSION['tx_captcha_string'];
-            $_SESSION['tx_captcha_string'] = '';
-
-            if (empty($captchaStr) || ($this->dataArr['captcha'] !== $captchaStr)) {
+            if (\TYPO3\CMS\Core\Utility\VersionNumberUtility::convertVersionNumberToInteger(ExtensionManagementUtility::getExtensionVersion('captcha')) >= 2000000) {
+                $result = \ThinkopenAt\Captcha\Utility::checkCaptcha($this->dataArr['captcha']);
+            } else {
+                session_start();
+                $result = !empty($_SESSION['tx_captcha_string']) && ($this->dataArr['captcha'] !== $_SESSION['tx_captcha_string']);
+                $_SESSION['tx_captcha_string'] = '';
+            }
+            if (!$result) {
                 $captcha = false;
                 $theField = 'captcha';
                 $this->failureMsg[$theField][] = $this->getFailure($theField, 'captcha', 'Wrong captcha!');

--- a/fe_adminLib.inc
+++ b/fe_adminLib.inc
@@ -1060,7 +1060,7 @@ class user_feAdmin
 	/*]]>*/
 </script>
 ';
-        $GLOBALS['TSFE']->additionalHeaderData['JSincludeFormupdate'] = '<script type="text/javascript" src="'.GeneralUtility::createVersionNumberedFilename($GLOBALS['TSFE']->absRefPrefix. ExtensionManagementUtility::extRelPath('direct_mail_subscription').'jsfunc.updateform.js').'"></script>';
+        $GLOBALS['TSFE']->additionalHeaderData['JSincludeFormupdate'] = '<script type="text/javascript" src="'.GeneralUtility::createVersionNumberedFilename($GLOBALS['TSFE']->absRefPrefix. ExtensionManagementUtility::siteRelPath('direct_mail_subscription').'jsfunc.updateform.js').'"></script>';
 
         return $JSPart;
     }

--- a/fe_adminLib.inc
+++ b/fe_adminLib.inc
@@ -788,7 +788,7 @@ class user_feAdmin
                 $result = \ThinkopenAt\Captcha\Utility::checkCaptcha($this->dataArr['captcha']);
             } else {
                 session_start();
-                $result = !empty($_SESSION['tx_captcha_string']) && ($this->dataArr['captcha'] !== $_SESSION['tx_captcha_string']);
+                $result = !empty($_SESSION['tx_captcha_string']) && ($this->dataArr['captcha'] === $_SESSION['tx_captcha_string']);
                 $_SESSION['tx_captcha_string'] = '';
             }
             if (!$result) {


### PR DESCRIPTION
Using "extRelPath" generates a path containing "../typo3conf/", which is invalid.

Added compatibility for TYPO3 extension "captcha" in version 2.0.0 or newer.