### PR TITLE
[BUGFIX] Prevent sending of confirmation mails multiple times

### DIFF
--- a/fe_adminLib.inc
+++ b/fe_adminLib.inc
@@ -1216,6 +1216,7 @@ class user_feAdmin
         if ($this->conf['setfixed']) {
             $theUid = intval($this->recUid);
             $origArr = $GLOBALS['TSFE']->sys_page->getRawRecord($this->theTable, $theUid);
+            $origHidden = $origArr['hidden'];
             $fD = GeneralUtility::_GP('fD');
             $sFK = GeneralUtility::_GP('sFK');
 
@@ -1254,13 +1255,17 @@ class user_feAdmin
                         $content = $this->getPlainTemplate('###TEMPLATE_SETFIXED_OK###');
                     }
 
+                    // Send confirmation mail only, if user record is still hidden.
+                    if ($origHidden == 1) {
                         // Compiling email
-                    $this->compileMail(
-                        'SETFIXED_'.$sFK,
-                        array($origArr),
-                        $origArr[$this->conf['email.']['field']],
-                        $this->conf['setfixed.']
-                    );
+                        $this->compileMail(
+                            'SETFIXED_' . $sFK,
+                            array($origArr),
+                            $origArr[$this->conf['email.']['field']],
+                            $this->conf['setfixed.']
+                        );
+                    }
+
                         // Clearing cache if set:
                     $this->clearCacheIfSet();
                     $this->setNoCacheHeader();


### PR DESCRIPTION
The link in the email confirmation could be sent several times, as there
is no time limit or a test, whether the account was already activated.

This adds a test, whether the record is still hidden. An email will only
be sent, in this case.

Resolves: #26